### PR TITLE
chore: Update renovate config

### DIFF
--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -86,5 +86,16 @@
       "depNameTemplate": "kubernetes/minikube",
       "datasourceTemplate": "github-releases",
     },
+    {
+      "description": "Update Helm values",
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/)values\.ya?ml$",
+      ],
+      "matchStrings": [
+        "\\s+repository: (?<depName>.+)\\s+tag: (?<currentValue>.+)",
+      ],
+      "datasourceTemplate": "docker",
+    },
   ],
 }


### PR DESCRIPTION
Updating Renovate config so we have automated updates for `k8s-events-forwarder` in `nri-kubernetes` and `nri-kube-events`