### PR TITLE
add build windows, docker, and manifest combination steps to release-integration

### DIFF
--- a/.github/workflows/reusable-release-integration.yml
+++ b/.github/workflows/reusable-release-integration.yml
@@ -35,6 +35,11 @@ on:
         type: boolean
         required: false
         default: false
+      windows_directory:
+        description: Location of Windows build files
+        type: string
+        required: false
+        default: ''
     # secrets need to be passed in for reusable workflows
     secrets:
       dockerhub_username:
@@ -201,8 +206,14 @@ jobs:
           DATE: ${{ needs.build-env-args.outputs.date }}
           TAG: ${{ needs.build-env-args.outputs.docker_image_tag }}
           WIN_VERSION: ${{ matrix.windows.tag }}
+          WIN_DIR: ${{ inputs.windows_directory }}
         run: |
-          ./buildWindows.ps1
+          if ([string]::IsNullOrEmpty($env:WIN_DIR)) {
+            ./build.ps1
+          } else {
+            $scriptPath = Join-Path $env:WIN_DIR "build.ps1"
+            & $scriptPath
+          }
       - name: Upload artifact for docker build step
         uses: actions/upload-artifact@v4
         with:
@@ -249,10 +260,18 @@ jobs:
           DATE: ${{ needs.build-env-args.outputs.date }}
           MATRIX_TAG: ${{ matrix.windows.tag }}
           PRE_RELEASE_DOCKER_IMAGE_TAG: "${{ needs.build-env-args.outputs.docker_image_tag }}-pre"
+          WIN_DIR: ${{ inputs.windows_directory }}
         shell: powershell
         run: |
           $env:FINAL_TAG = "${env:DOCKER_IMAGE_NAME}:${env:PRE_RELEASE_DOCKER_IMAGE_TAG}-windows-${env:MATRIX_TAG}"
-          docker build --platform windows/amd64 -f Dockerfile.windows `
+
+          if ([string]::IsNullOrEmpty($env:WIN_DIR)) {
+            $dockerfilePath = "Dockerfile.windows"
+          } else {
+            $dockerfilePath = Join-Path $env:WIN_DIR "Dockerfile.windows"
+          }
+
+          docker build --platform windows/amd64 -f $dockerfilePath `
             --build-arg "BASE_IMAGE_TAG=${env:MATRIX_TAG}" `
             --build-arg "COMMIT=${env:COMMIT}" `
             --build-arg "DATE=${env:DATE}" `
@@ -267,10 +286,17 @@ jobs:
           DATE: ${{ needs.build-env-args.outputs.date }}
           MATRIX_TAG: ${{ matrix.windows.tag }}
           DOCKER_IMAGE_TAG: "${{ needs.build-env-args.outputs.docker_image_tag }}"
+          WIN_DIR: ${{ inputs.windows_directory }}
           FINAL_TAG: "${{ inputs.docker_image_name }}:${{ needs.build-env-args.outputs.docker_image_tag }}-windows-${{ matrix.windows.tag }}"
         shell: powershell
         run: |
-          docker build --platform windows/amd64 -f Dockerfile.windows `
+          if ([string]::IsNullOrEmpty($env:WIN_DIR)) {
+            $dockerfilePath = "Dockerfile.windows"
+          } else {
+            $dockerfilePath = Join-Path $env:WIN_DIR "Dockerfile.windows"
+          }
+
+          docker build --platform windows/amd64 -f $dockerfilePath `
             --build-arg "BASE_IMAGE_TAG=${env:MATRIX_TAG}" `
             --build-arg "COMMIT=${env:COMMIT}" `
             --build-arg "DATE=${env:DATE}" `

--- a/.github/workflows/reusable-release-integration.yml
+++ b/.github/workflows/reusable-release-integration.yml
@@ -311,73 +311,30 @@ jobs:
     env:
       DOCKER_IMAGE_NAME: ${{ inputs.docker_image_name }}
       DOCKER_IMAGE_TAG: ${{ needs.build-env-args.outputs.docker_image_tag }}
+      REGCTL_VERSION: v0.8.3
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Create and Push Manifest
+      - name: Install regctl
         run: |
-          IMAGE_TAG="${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}-pre" 
-          
-          if [ "${{ github.event.release.prerelease }}" = "false" ] ; then
-            IMAGE_TAG="${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
-          fi
-          echo "IMAGE_TAG=${IMAGE_TAG}"
-          
-          windows2019_image="${IMAGE_TAG}-windows-ltsc2019"
-          windows2022_image="${IMAGE_TAG}-windows-ltsc2022"
-
-          docker pull $IMAGE_TAG
-
-          echo "Extracting Linux architecture digests..."
-          manifest_data=$(docker manifest inspect ${IMAGE_TAG})
-
-          arm64_image=$(echo "$manifest_data" | jq -r --arg name "$DOCKER_IMAGE_NAME" \
-            '.manifests[] | select(.platform.architecture=="arm64" and .platform.os=="linux") | $name + "@" + .digest')
-
-          armv7_image=$(echo "$manifest_data" | jq -r --arg name "$DOCKER_IMAGE_NAME" \
-            '.manifests[] | select(.platform.architecture=="arm" and .platform.variant=="v7" and .platform.os=="linux") | $name + "@" + .digest')
-
-          amd64_image=$(echo "$manifest_data" | jq -r --arg name "$DOCKER_IMAGE_NAME" \
-            '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | $name + "@" + .digest')
-
-          echo "Linux ARM64 image: ${arm64_image}"
-          echo "Linux ARMv7 image: ${armv7_image}"
-          echo "Linux AMD64 image: ${amd64_image}"
-          echo "Windows 2019 image: ${windows2019_image}"
-          echo "Windows 2022 image: ${windows2022_image}"
-
-          echo "Creating new manifest with the same name with all architectures..."
-          manifest_cmd="docker manifest create ${IMAGE_TAG}"
-
-          [ -n "${arm64_image}" ] && manifest_cmd="${manifest_cmd} --amend '${arm64_image}'"
-          [ -n "${armv7_image}" ] && manifest_cmd="${manifest_cmd} --amend '${armv7_image}'"
-          [ -n "${amd64_image}" ] && manifest_cmd="${manifest_cmd} --amend '${amd64_image}'"
-          docker manifest inspect "${windows2019_image}" &>/dev/null && manifest_cmd="${manifest_cmd} --amend '${windows2019_image}'"
-          docker manifest inspect "${windows2022_image}" &>/dev/null && manifest_cmd="${manifest_cmd} --amend '${windows2022_image}'"
-
-          echo "Executing: ${manifest_cmd}"
-          eval $manifest_cmd
-
-          echo "Annotating Windows images..."
-          if docker manifest inspect "${windows2019_image}" &>/dev/null; then
-            docker manifest annotate ${IMAGE_TAG} ${windows2019_image} \
-              --os windows --arch amd64 --os-version 10.0.17763
-          fi
-
-          if docker manifest inspect "${windows2022_image}" &>/dev/null; then
-            docker manifest annotate ${IMAGE_TAG} ${windows2022_image} \
-              --os windows --arch amd64 --os-version 10.0.20348
-          fi
-
-          echo "Pushing combined manifest..."
-          docker manifest push ${IMAGE_TAG}
-
+          mkdir -p $HOME/bin
+          curl -L "https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64" > $HOME/bin/regctl
+          chmod 755 $HOME/bin/regctl
+          export PATH=$HOME/bin:$PATH
+          echo "$HOME/bin" >> $GITHUB_PATH
+          regctl version
+      - name: Create and Push Manifest
+        env: 
+          DOCKER_IMAGE_NAME: ${{ inputs.docker_image_name }}
+          DOCKER_IMAGE_TAG: ${{ needs.build-env-args.outputs.docker_image_tag }}
+        run: |
+          chmod +x ./windows/util/create-manifest.sh
+          ./windows/util/create-manifest.sh --docker-image-name ${DOCKER_IMAGE_NAME} --docker-image-tag ${DOCKER_IMAGE_TAG} --is-prerelease "${{ github.event.release.prerelease }}"
+  
   open-pr:
     name: Update version and appVersion and open pr
     needs: [ docker-integration ]

--- a/.github/workflows/reusable-release-integration.yml
+++ b/.github/workflows/reusable-release-integration.yml
@@ -30,6 +30,11 @@ on:
         type: string
         required: false
         default: .appVersion
+      enable_windows:
+        description: Whether to enable windows build
+        type: boolean
+        required: false
+        default: false
     # secrets need to be passed in for reusable workflows
     secrets:
       dockerhub_username:
@@ -52,6 +57,23 @@ env:
   ORIGINAL_REPO_NAME: ${{ github.event.repository.full_name }}
 
 jobs:
+  build-env-args:
+    name: Build env args
+    runs-on: ubuntu-latest
+    outputs:
+      new-version: ${{ steps.build-env-args.outputs.new-version }}
+      docker_image_tag: ${{ steps.build-env-args.outputs.docker-image-tag }}
+      date: ${{ steps.build-env-args.outputs.date }}
+    steps:
+      - name: Build env args
+        id: build-env-args
+        run: |
+          echo "${{ github.event.release.tag_name }}" | grep -E '^[v]?[0-9.]*[0-9]$'
+          DOCKER_IMAGE_TAG=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
+          echo "docker-image-tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "DATE=`date`" >> $GITHUB_OUTPUT
+          echo "new-version=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+
   build:
     name: Build integration for
     runs-on: ubuntu-latest
@@ -68,7 +90,7 @@ jobs:
           echo "DATE=`date`" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: './go.mod'
       - name: Build integration
@@ -151,6 +173,185 @@ jobs:
             -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
             -t $DOCKER_IMAGE_NAME:latest \
             .
+
+  build-windows:
+    name: Build Windows integration for
+    if: ${{ inputs.enable_windows }}
+    needs: [ build-env-args ]
+    strategy:
+      fail-fast: true
+      matrix:
+        windows:
+          # Tag must exist in both https://hub.docker.com/_/microsoft-windows-servercore and
+          # https://hub.docker.com/_/microsoft-windows-nanoserver, and must be matched with the runner.
+          - runner: windows-2019
+            tag: ltsc2019
+          - runner: windows-2022
+            tag: ltsc2022
+    runs-on: ${{ matrix.windows.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Build integration
+        shell: powershell
+        env:
+          COMMIT: ${{ github.sha }}
+          DATE: ${{ needs.build-env-args.outputs.date }}
+          TAG: ${{ needs.build-env-args.outputs.docker_image_tag }}
+          WIN_VERSION: ${{ matrix.windows.tag }}
+        run: |
+          ./buildWindows.ps1
+      - name: Upload artifact for docker build step
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 1
+          name: ${{ inputs.repo_name }}-windows-${{ matrix.windows.tag }}-amd64
+          path: ${{ inputs.artifact_path }}${{ inputs.repo_name }}-windows-${{ matrix.windows.tag }}-amd64.exe
+  
+  docker-integration-windows:
+    name: Release docker
+    needs: [ build-env-args, build-windows ]
+    strategy:
+      fail-fast: true
+      matrix:
+        windows:
+          - runner: windows-2019
+            tag: ltsc2019
+          - runner: windows-2022
+            tag: ltsc2022
+    runs-on: ${{ matrix.windows.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Windows artifacts from build job with bin path
+        if: ${{ inputs.artifact_path }}
+        uses: actions/download-artifact@v4
+        with:
+          pattern: '*-windows-*'
+          path: bin
+          merge-multiple: true
+      - name: Download Windows artifacts from build job without bin path
+        if: ${{ ! inputs.artifact_path }}
+        uses: actions/download-artifact@v4
+        with:
+          pattern: '*-windows-*'
+          merge-multiple: true
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.dockerhub_username }}
+          password: ${{ secrets.dockerhub_token }}
+      - name: Build and push windows docker prerelease image
+        if: ${{ github.event.release.prerelease }}
+        env:
+          DOCKER_IMAGE_NAME: ${{ inputs.docker_image_name }}
+          COMMIT: ${{ github.sha }}
+          DATE: ${{ needs.build-env-args.outputs.date }}
+          MATRIX_TAG: ${{ matrix.windows.tag }}
+          PRE_RELEASE_DOCKER_IMAGE_TAG: "${{ needs.build-env-args.outputs.docker_image_tag }}-pre"
+        shell: powershell
+        run: |
+          $env:FINAL_TAG = "${env:DOCKER_IMAGE_NAME}:${env:PRE_RELEASE_DOCKER_IMAGE_TAG}-windows-${env:MATRIX_TAG}"
+          docker build --platform windows/amd64 -f Dockerfile.windows `
+            --build-arg "BASE_IMAGE_TAG=${env:MATRIX_TAG}" `
+            --build-arg "COMMIT=${env:COMMIT}" `
+            --build-arg "DATE=${env:DATE}" `
+            --build-arg "TAG=${env:DOCKER_IMAGE_TAG}" `
+              -t "${env:FINAL_TAG}" .
+          docker push "${env:FINAL_TAG}"
+      - name: Build and push windows docker release image
+        if: ${{ !github.event.release.prerelease }}
+        env:
+          DOCKER_IMAGE_NAME: ${{ inputs.docker_image_name }}
+          COMMIT: ${{ github.sha }}
+          DATE: ${{ needs.build-env-args.outputs.date }}
+          MATRIX_TAG: ${{ matrix.windows.tag }}
+          DOCKER_IMAGE_TAG: "${{ needs.build-env-args.outputs.docker_image_tag }}"
+          FINAL_TAG: "${{ inputs.docker_image_name }}:${{ needs.build-env-args.outputs.docker_image_tag }}-windows-${{ matrix.windows.tag }}"
+        shell: powershell
+        run: |
+          docker build --platform windows/amd64 -f Dockerfile.windows `
+            --build-arg "BASE_IMAGE_TAG=${env:MATRIX_TAG}" `
+            --build-arg "COMMIT=${env:COMMIT}" `
+            --build-arg "DATE=${env:DATE}" `
+            --build-arg "TAG=${env:DOCKER_IMAGE_TAG}" `
+              -t "${env:FINAL_TAG}" .
+          docker push "${env:FINAL_TAG}"
+
+  create-multi-platform-arch-manifest:
+    name: Create Multi-Arch-Multi-Platform Manifest
+    runs-on: ubuntu-latest
+    needs: [ build-env-args, docker-integration, docker-integration-windows ]
+    env:
+      DOCKER_IMAGE_NAME: ${{ inputs.docker_image_name }}
+      DOCKER_IMAGE_TAG: ${{ needs.build-env-args.outputs.docker_image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create and Push Manifest
+        run: |
+          IMAGE_TAG="${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}-pre" 
+          
+          if [ "${{ github.event.release.prerelease }}" = "false" ] ; then
+            IMAGE_TAG="${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
+          fi
+          echo "IMAGE_TAG=${IMAGE_TAG}"
+          
+          windows2019_image="${IMAGE_TAG}-windows-ltsc2019"
+          windows2022_image="${IMAGE_TAG}-windows-ltsc2022"
+
+          docker pull $IMAGE_TAG
+
+          echo "Extracting Linux architecture digests..."
+          manifest_data=$(docker manifest inspect ${IMAGE_TAG})
+
+          arm64_image=$(echo "$manifest_data" | jq -r --arg name "$DOCKER_IMAGE_NAME" \
+            '.manifests[] | select(.platform.architecture=="arm64" and .platform.os=="linux") | $name + "@" + .digest')
+
+          armv7_image=$(echo "$manifest_data" | jq -r --arg name "$DOCKER_IMAGE_NAME" \
+            '.manifests[] | select(.platform.architecture=="arm" and .platform.variant=="v7" and .platform.os=="linux") | $name + "@" + .digest')
+
+          amd64_image=$(echo "$manifest_data" | jq -r --arg name "$DOCKER_IMAGE_NAME" \
+            '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | $name + "@" + .digest')
+
+          echo "Linux ARM64 image: ${arm64_image}"
+          echo "Linux ARMv7 image: ${armv7_image}"
+          echo "Linux AMD64 image: ${amd64_image}"
+          echo "Windows 2019 image: ${windows2019_image}"
+          echo "Windows 2022 image: ${windows2022_image}"
+
+          echo "Creating new manifest with the same name with all architectures..."
+          manifest_cmd="docker manifest create ${IMAGE_TAG}"
+
+          [ -n "${arm64_image}" ] && manifest_cmd="${manifest_cmd} --amend '${arm64_image}'"
+          [ -n "${armv7_image}" ] && manifest_cmd="${manifest_cmd} --amend '${armv7_image}'"
+          [ -n "${amd64_image}" ] && manifest_cmd="${manifest_cmd} --amend '${amd64_image}'"
+          docker manifest inspect "${windows2019_image}" &>/dev/null && manifest_cmd="${manifest_cmd} --amend '${windows2019_image}'"
+          docker manifest inspect "${windows2022_image}" &>/dev/null && manifest_cmd="${manifest_cmd} --amend '${windows2022_image}'"
+
+          echo "Executing: ${manifest_cmd}"
+          eval $manifest_cmd
+
+          echo "Annotating Windows images..."
+          if docker manifest inspect "${windows2019_image}" &>/dev/null; then
+            docker manifest annotate ${IMAGE_TAG} ${windows2019_image} \
+              --os windows --arch amd64 --os-version 10.0.17763
+          fi
+
+          if docker manifest inspect "${windows2022_image}" &>/dev/null; then
+            docker manifest annotate ${IMAGE_TAG} ${windows2022_image} \
+              --os windows --arch amd64 --os-version 10.0.20348
+          fi
+
+          echo "Pushing combined manifest..."
+          docker manifest push ${IMAGE_TAG}
+
   open-pr:
     name: Update version and appVersion and open pr
     needs: [ docker-integration ]
@@ -184,7 +385,7 @@ jobs:
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
 
       - name: Set up Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: './go.mod'
 

--- a/.github/workflows/reusable-release-integration.yml
+++ b/.github/workflows/reusable-release-integration.yml
@@ -332,9 +332,9 @@ jobs:
           DOCKER_IMAGE_NAME: ${{ inputs.docker_image_name }}
           DOCKER_IMAGE_TAG: ${{ needs.build-env-args.outputs.docker_image_tag }}
         run: |
-          chmod +x ./windows/util/create-manifest.sh
-          ./windows/util/create-manifest.sh --docker-image-name ${DOCKER_IMAGE_NAME} --docker-image-tag ${DOCKER_IMAGE_TAG} --is-prerelease "${{ github.event.release.prerelease }}"
-  
+          chmod +x ./src/utils/create-combined-manifest.sh
+          ./src/utils/create-combined-manifest.sh --docker-image-name ${DOCKER_IMAGE_NAME} --docker-image-tag ${DOCKER_IMAGE_TAG} --is-prerelease "${{ github.event.release.prerelease }}"
+
   open-pr:
     name: Update version and appVersion and open pr
     needs: [ docker-integration ]

--- a/src/utils/create-combined-manifest.sh
+++ b/src/utils/create-combined-manifest.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
+DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME:-""}
+DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-""}
+IS_PRERELEASE=${IS_PRERELEASE:-"true"}
+
+export GGCR_DISABLE_CACHE=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --docker-image-name) DOCKER_IMAGE_NAME="$2"; shift 2 ;;
+    --docker-image-tag) DOCKER_IMAGE_TAG="$2"; shift 2 ;;
+    --is-prerelease) IS_PRERELEASE="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "${DOCKER_IMAGE_NAME}" ]]; then
+  echo "Error: DOCKER_IMAGE_NAME is required."
+  exit 1
+fi
+if [[ -z "${DOCKER_IMAGE_TAG}" ]]; then
+  echo "Error: DOCKER_IMAGE_TAG is required."
+  exit 1
+fi
+if [[ -z "${IS_PRERELEASE}" ]]; then
+  echo "Error: IS_PRERELEASE is required."
+  exit 1
+fi
+
+if [[ "${IS_PRERELEASE}" != "false" ]]; then 
+  IMAGE_TAG="${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}-pre"
+else
+  IMAGE_TAG="${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
+fi
+echo "IMAGE_TAG=${IMAGE_TAG}"
+
+linux_manifest=$(regctl manifest get "${IMAGE_TAG}" --format '{{jsonPretty .}}')
+echo "Extracted Linux manifest: "
+echo "${linux_manifest}"
+
+arm64_digest=$(jq -r '.manifests[] | select(.platform.architecture=="arm64" and .platform.os=="linux") | .digest' <<< "$linux_manifest")
+armv7_digest=$(jq -r '.manifests[] | select(.platform.architecture=="arm" and .platform.variant=="v7" and .platform.os=="linux") | .digest' <<< "$linux_manifest")
+amd64_digest=$(jq -r '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest' <<< "$linux_manifest")
+all_attestations=$(jq -r '.manifests[] | select(.platform.architecture=="unknown" and .platform.os=="unknown" and .annotations["vnd.docker.reference.type"]=="attestation-manifest")' <<< "$linux_manifest")
+attestations_array=$(echo ${all_attestations} | jq -s '.')
+windows2019_image="${IMAGE_TAG}-windows-ltsc2019"
+windows2022_image="${IMAGE_TAG}-windows-ltsc2022"
+
+declare -A images=(
+  [arm64]="${DOCKER_IMAGE_NAME}@${arm64_digest}"
+  [armv7]="${DOCKER_IMAGE_NAME}@${armv7_digest}"
+  [amd64]="${DOCKER_IMAGE_NAME}@${amd64_digest}"
+  [win2019]="${windows2019_image}"
+  [win2022]="${windows2022_image}"
+)
+
+for arch in "${!images[@]}"; do
+  [[ -n "${images[$arch]}" ]] && echo "${arch^^} image: ${images[$arch]}"
+done
+
+echo "Creating new manifest..."
+manifest_cmd="docker manifest create ${IMAGE_TAG}"
+for img in "${images[@]}"; do
+  [[ -n "$img" ]] && manifest_cmd+=" --amend $img"
+done
+
+echo "Executing: ${manifest_cmd}"
+eval $manifest_cmd
+echo "Manifest created successfully."
+
+echo "Adding linux image attestation-manifests"
+docker manifest inspect "${IMAGE_TAG}" > new_manifest.json
+jq --argjson atts "${attestations_array}" '.manifests += $atts' new_manifest.json > updated_manifest.json
+regctl manifest put ${IMAGE_TAG} < updated_manifest.json
+regctl manifest get "${IMAGE_TAG}" --format '{{jsonPretty .}}'


### PR DESCRIPTION
- add optional windows build, docker image build and upload, and then manifestion combining for all linux arches and windows 2019 and 2022
- `enable_windows` is the option flag
- create-combined-manifest.sh uses regctl to copy over attestation-manifests