### PR TITLE
chore: automate helm version updates for CI

### DIFF
--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -105,5 +105,15 @@
       ],
       "datasourceTemplate": "docker",
     },
+    {
+      "description": "Update Helm versions for CI",
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/.+\\.ya?ml$"],
+      "matchStrings": [
+        "uses: azure/setup-helm@v4\\s+with:\\s+version: '(?<currentValue>.*)'"
+      ],
+      "depNameTemplate": "helm/helm",
+      "datasourceTemplate": "github-releases"
+    }
   ],
 }


### PR DESCRIPTION
this config created a PR successfully in my fork of the prometheus agent repo:
<img width="913" height="521" alt="Screenshot 2026-01-06 at 8 58 54 PM" src="https://github.com/user-attachments/assets/713a1a80-6062-4c25-80f8-9251c18224fd" />
